### PR TITLE
[update] add get drive number (letter) method

### DIFF
--- a/src/Seeed_SFUD.cpp
+++ b/src/Seeed_SFUD.cpp
@@ -75,6 +75,16 @@ namespace fs {
             _pdrv = 0xFF;
         }
     }
+    uint8_t SFUDFS::getPhysicalDriveNumber() {
+        return _pdrv;
+    }
+    String SFUDFS::getDriveLetter() {
+        if (_pdrv == 0xFF) {
+            // Card not initialized
+            return "";
+        }
+        return String(_pdrv) + ":";
+    }
     sfud_type_t SFUDFS::flashType() {
         if (_pdrv == 0xFF) {
             return FLASH_NONE;

--- a/src/Seeed_SFUD.h
+++ b/src/Seeed_SFUD.h
@@ -55,6 +55,9 @@ namespace fs {
         //call this when a card is removed. It will allow you to insert and initialise a new card.
         boolean end();
 
+        uint8_t getPhysicalDriveNumber();
+        String getDriveLetter();
+
         sfud_type_t flashType();
         uint64_t flashSize();
         uint64_t totalBytes();


### PR DESCRIPTION
- added getPhysicalDriveNumber( )
- added getDriveLetter( )

In WioTerminal, I found a issue that my program not work correctly when using Flash (SFUD) and SD card at the same time.
The cause is that the drive letter (drive number) of the path is not correctly identified during file processing.

To solve this problem, a drive letter should be added to the beginning of the file path (e.g. "0:/dir/test.txt"), but the library did not provide this functionality, so I propose to add it.

I also pullrequested to [Seeed_Arduino_FS](https://github.com/Seeed-Studio/Seeed_Arduino_FS) repo.